### PR TITLE
Allow toolbar active on MIT puzzle archive site.

### DIFF
--- a/chrome-extension/src/background/ConnectionManager.js
+++ b/chrome-extension/src/background/ConnectionManager.js
@@ -87,7 +87,22 @@ function initializeHuntToolbar(port, toolbarInfo) {
 
     function handleDiscoveredPageValue(snap) {
         // TODO only add discoveredPage if the hunt is current
+        function shouldAutoIgnoreDiscoveredPage(toolbarInfo) {
+            // ignore archive pages
+            if (/web\.mit\.edu/i.test(toolbarInfo.host)) {
+                return true;
+            }
+            // ignore solution pages
+            if (/\/solution\//i.test(toolbarInfo.path)) {
+                return true;
+            }
+            return false;
+        }
         if (snap.numChildren() === 0) {
+            if (shouldAutoIgnoreDiscoveredPage(toolbarInfo)) {
+                return console.log("[auto-ignore/discoveredPages]",
+                    toolbarInfo.host, toolbarInfo.path, toolbarInfo.title);
+            }
             console.log("[firebase/discoveredPages]",
                 toolbarInfo.host, toolbarInfo.path, toolbarInfo.title);
             const pushed = db.ref("discoveredPages/" + toolbarInfo.huntKey).push({

--- a/chrome-extension/src/background/background.js
+++ b/chrome-extension/src/background/background.js
@@ -128,20 +128,20 @@ function fetchTabInfoForLocation(hostname, pathname, callback) {
         }
     } else if (MIT_PUZZLE_ARCHIVE_PATTERN.test(hostname + pathname)) {
         // Archive: web.mit.edu/puzzle/www/{year}
-        var yearMatch = (hostname + pathname).match(MIT_PUZZLE_ARCHIVE_PATTERN);
+        const yearMatch = (hostname + pathname).match(MIT_PUZZLE_ARCHIVE_PATTERN);
         if (yearMatch && yearMatch[1]) {
             // Find hunt that matches archive location's year
-            var year = yearMatch[1];
-            selectOnlyWhereChildEquals("hunts",
-            "year", year, function(hunt) {
-                if (!hunt) {
+            const year = yearMatch[1];
+            selectOnlyWhereChildEquals("huntHostNames",
+            "hunt", year, function(huntHostName) {
+                if (!huntHostName) {
                     callback({ toolbarType: "none" });
                     return;
                 }
-                var huntKey = hunt.key;
+                const huntKey = huntHostName.val().hunt;
 
                 // See if any puzzles in this hunt match the current path
-                var trimPathname = pathname.replace(/\/puzzle\/www\/\d{4}\//i, "");
+                const trimPathname = pathname.replace(/\/puzzle\/www\/\d{4}\//i, "");
                 tryFindPuzzle(huntKey, trimPathname, callback);
             });
         }

--- a/chrome-extension/src/background/background.js
+++ b/chrome-extension/src/background/background.js
@@ -76,7 +76,7 @@ function fetchTabInfoForLocation(hostname, pathname, callback) {
     function tryFindPuzzle(huntKey, pathSearch, callback) {
         selectAllWhereChildEquals("puzzles",
             "hunt", huntKey, function(puzzlesSnapshot) {
-                var didFindPuzzle = puzzlesSnapshot.find(function(p) {
+                var didFindPuzzle = puzzlesSnapshot.forEach(function(p) {
                     const puzzlePath = p.val().path;
                     if (!puzzlePath) {
                         return false;
@@ -126,19 +126,19 @@ function fetchTabInfoForLocation(hostname, pathname, callback) {
                     }
                 });
         }
-    } else if ((hostname + pathname).test(MIT_PUZZLE_ARCHIVE)) {
+    } else if (MIT_PUZZLE_ARCHIVE_PATTERN.test(hostname + pathname)) {
         // Archive: web.mit.edu/puzzle/www/{year}
-        var yearMatch = (location + pathname).match(MIT_PUZZLE_ARCHIVE);
+        var yearMatch = (hostname + pathname).match(MIT_PUZZLE_ARCHIVE_PATTERN);
         if (yearMatch && yearMatch[1]) {
             // Find hunt that matches archive location's year
             var year = yearMatch[1];
-            selectOnlyWhereChildEquals("huntHostNames",
-            "year", year, function(huntHostName) {
-                if (!huntHostName) {
+            selectOnlyWhereChildEquals("hunts",
+            "year", year, function(hunt) {
+                if (!hunt) {
                     callback({ toolbarType: "none" });
                     return;
                 }
-                var huntKey = huntHostName.val().hunt;
+                var huntKey = hunt.key;
 
                 // See if any puzzles in this hunt match the current path
                 var trimPathname = pathname.replace(/\/puzzle\/www\/\d{4}\//i, "");


### PR DESCRIPTION
Visiting puzzle pages at `web.mit.edu/puzzle/www/{year}/` activates toolbar for that given year's hunt / puzzle.  Useful for reference after live hunt domain is taken down every year and redirected to archives.